### PR TITLE
Changed Operator-Importing-for-Restricted-Networks to be more user friendly

### DIFF
--- a/Operator-Importing-for-Restricted-Networks/README.md
+++ b/Operator-Importing-for-Restricted-Networks/README.md
@@ -1,15 +1,16 @@
-# Important!!
-This Ansible Playbook is for PoC purposes only, and can & will be written in a more finesse manner;
-For the purpose of PoC, it is definitely satisfying.
-
 # Before Running The Playbook
 1. Make sure to access: https://console.redhat.com/openshift/install/pull-secret and download a pull-secret.json file to `/tmp/pull-secret.json`
 
-2. Change Variables in the `playbook.yaml` file based on your required operator
+2. Change Variables in the `playbook.yaml` file based on your required operator:
+	1. index_image - Choose one of the following: redhat-operator/certified-operator/community-operator
+	2. index_image_version - cluster major version (with v prefix)
+	> e.g: v4.8
+	3. required_operator - Operator name (partial ok)
+	> e.g: local/local-storage/local-storage-operator
 
 ## Please Note
 
-1. Required Packages - Run the following commands prior to running the playbook;
+1. Required Packages - Run the following commands prior to running the playbook:
 
 ```bash
 sudo ansible-galaxy collection install community.crypto
@@ -17,8 +18,39 @@ sudo ansible-galaxy collection install containers.podman
 sudo ansible-galaxy collection install community.general
 ```
 
-2. The Ansible Playbook should be running with "sudo" due to elevated privilieges required to run some of the tasks.
+2. The Ansible Playbook should be running with "sudo" due to elevated privilieges required to run some of the tasks:
 ```bash
 sudo ansible-playbook playbook.yaml
 ```
 
+3. The ansible-playbook will create a tar.gz file, copy it to your restricted network:
+---
+## Post-running
+1. Un-tar the tar.gz file
+```bash
+tar xzvf OPERATOR_NAME-VERSION.tar.gz
+```
+
+2. Start the local repository on a server which contains the podman package:
+```bash
+bash data/repository/start-repository.sh
+```
+
+3. Change the placeholer at imageContentSourcePolicy.yaml, catalogSource.yaml, run.sh from MY_REGISTRY:5000 to your internal image registry URL:
+```bash
+cd data
+sed -i 's/MY_REGISTRY:5000/INTERNAL_REGISTRY:PORT/' imageContentSourcePolicy.yaml catalogSource.yaml run.sh
+```
+> Change INTERNAL_REGISTRY:PORT to your intenal registry.
+
+4. Push the images to your internal registry:
+```bash
+sudo bash run.sh
+```
+
+5. Add the operator to Openshift:
+```bash
+oc apply -f imageContentSourcePolicy.yaml
+oc apply -f catalogSource.yaml
+```
+> On openshift environments older than 4.7, imageContentSourcePolicy updates will resault in nodes rollout so wait until they finish oc the catalogSource udpate.

--- a/Operator-Importing-for-Restricted-Networks/playbook.yaml
+++ b/Operator-Importing-for-Restricted-Networks/playbook.yaml
@@ -1,25 +1,25 @@
 ---
 - hosts: localhost
   vars:
-    # In use in both: "run-custom-index-container-and-mirror" and "cleanup" roles
-    index_image: redhat-operator
-    index_image_version: v4.6
+    index_image: # Choose one of the following: redhat-operator/certified-operator/community-operator
+    index_image_version: # cluster major version (with v prefix), e.g: v4.8
+    required_operator: # Operator name (partial ok), e.g: local/local-storage/local-storage-operator
 
-  roles:
-
-    - role: deploy-local-registry
+  tasks:
+  - block:
+    - include_role: 
+        name: deploy-local-registry
+      # You may change this credentials if you don't want the default docker repository credentials
       vars:
         user: "dummy"
         password: "dummy"
-
-    - role: install-required-tools
-      vars:
-        ocp_version: "4.6.27"
-        opm_version: "v1.18.0"
-        grpcurl_latest_version_number: "v1.8.5"
-
-    - role: run-custom-index-container-and-mirror 
-      vars:
-        required_operator: mesh
-    
-    - role: cleanup
+  
+    - include_role:
+        name: install-required-tools
+  
+    - include_role:
+        name: run-custom-index-container-and-mirror 
+  
+    always:
+    - include_role:
+        name: cleanup

--- a/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/files/registry/htpasswd
+++ b/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/files/registry/htpasswd
@@ -1,1 +1,0 @@
-dummy:$2y$05$i/a6mCrzAcDHg75agZucuOZa4mKd5hOSx1sEQ0zV7uBmw0BGRp80W

--- a/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/files/registry/start-repository.sh
+++ b/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/files/registry/start-repository.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 # prepare prerequisites
-mkdir -p /tmp/myregistry/{auth,certs,data}
+mkdir -p /tmp/myregistry/{auth,certs}
+ln -s $(dirname $(readlink -f $0))/.. /tmp/myregistry/data
+chcon -Rt svirt_sandbox_file_t $(dirname $(readlink -f $0))/..
 grep -q myregistry /etc/hosts || echo "127.0.0.1 myregistry quay.io" >> /etc/hosts
-cp htpasswd /tmp/myregistry/auth
-openssl req -newkey rsa:4096 -nodes -sha256 -keyout /tmp/myregistry/certs/domain.key -x509 -days 365 -out /tmp/myregistry/certs/domain.crt -subj "/CN=myregistry"
+cp $(dirname $(readlink -f $0))/htpasswd /tmp/myregistry/auth
+openssl req -newkey rsa:4096 -nodes -sha256 -keyout /tmp/myregistry/certs/myregistry.key -x509 -days 365 -out /tmp/myregistry/certs/myregistry.crt -subj "/CN=myregistry"
 
 # start repository container
 podman run --name myregistry -d -p 5000:5000 \
@@ -12,9 +14,9 @@ podman run --name myregistry -d -p 5000:5000 \
 -e REGISTRY_AUTH_HTPASSWD_REALM="Registry" \
 -e REGISTRY_HTTP_SECRET="ALongRandomSecretForRegistry" \
 -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
--e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/myregistry_crt.crt \
--e REGISTRY_HTTP_TLS_KEY=/certs/myregistry_key.pem \
+-e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/myregistry.crt \
+-e REGISTRY_HTTP_TLS_KEY=/certs/myregistry.key \
 -v /tmp/myregistry/data:/var/lib/registry:z \
 -v /tmp/myregistry/auth:/auth:z \
 -v /tmp/myregistry/certs:/certs:z \
-image: docker.io/library/registry:2
+docker.io/library/registry:2

--- a/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/files/registry/stop-repository.sh
+++ b/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/files/registry/stop-repository.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -l
+podman stop myregistry
+podman rm myregistry
+rm -rf /tmp/myregistry

--- a/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/tasks/generate-pull-secret.yaml
+++ b/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/tasks/generate-pull-secret.yaml
@@ -6,20 +6,19 @@
   shell: echo -n "{{user}}:{{password}}" | base64 -w0
   register: username_password_base64
   
+- name: append myregistry:5000 to pull-secret.json
+  shell: "cat <<< $(jq -c '.auths += {\"myregistry:5000\": {\"auth\":\"{{ username_password_base64.stdout }}\"}}' /tmp/pull-secret.json) > /tmp/pull-secret.json"
+
 - name: "mkdir for root auth.json (based on an official solution https://access.redhat.com/solutions/5312991)"
   file:
     path: /run/containers/0
     state: directory
 
-- name: Append dummy:dummy login for myregistry:5000 in /tmp/pull-secret.json
-  command: "jq '.auths += {\"myregistry:5000\": {\"auth\": \"{{username_password_base64.stdout}}\"}}' /tmp/pull-secret.json"
-  register: data
-
 - name: generate auth.json
   copy:
     dest: /run/containers/0/auth.json
-    content: |
-      {{ data.stdout }}
+    src: /tmp/pull-secret.json
+    remote_src: yes
 
 - name: Copy pull-secret.json
   template:

--- a/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/tasks/run-registry.yaml
+++ b/Operator-Importing-for-Restricted-Networks/roles/deploy-local-registry/tasks/run-registry.yaml
@@ -100,10 +100,14 @@
         REGISTRY_HTTP_TLS_CERTIFICATE: /certs/myregistry_crt.crt
         REGISTRY_HTTP_TLS_KEY: /certs/myregistry_key.pem
 
-- name: Copy registryimage start command
+- name: Copy internal registry operatin scripts
   copy:
     src: registry
     dest: /tmp/myregistry/data/
+    mode: '0755'
+
+- name: Generate htpasswd file for start-repository.sh
+  command: htpasswd -bBc /tmp/myregistry/data/registry/htpasswd {{user}} {{password}}
 
 - name: Podman save the registry image to tar
   shell: "podman save > /tmp/myregistry/data/registry/registryimage.tar docker.io/library/registry:2"

--- a/Operator-Importing-for-Restricted-Networks/roles/install-required-tools/tasks/main.yml
+++ b/Operator-Importing-for-Restricted-Networks/roles/install-required-tools/tasks/main.yml
@@ -16,15 +16,21 @@
     path: /usr/local/bin/grpcurl
   register: result_grpcurl
 
-- name: "check if openshift client (oc)  already installed"
+- name: "check if openshift client (oc) already installed"
   stat:
     path: /usr/local/bin/oc
   register: result_oc
 
-- name: "installing grpcurl {{ grpcurl_latest_version_number }}"
+- name: "Check latest grpcurl version"
+  shell: 'curl --silent https://github.com/fullstorydev/grpcurl/releases/latest | sed -r "s/^.*tag\/v(.*)\".*$/\1/"'
+  register: grpcurl_latest
+  changed_when: false
+  failed_when: false
+
+- name: "installing grpcurl v{{grpcurl_latest.stdout}}"
   unarchive:
     remote_src: yes
-    src: "https://github.com/fullstorydev/grpcurl/releases/download/{{grpcurl_latest_version_number}}/grpcurl_{{grpcurl_latest_version_number | replace('v','')}}_linux_x86_64.tar.gz"
+    src: "https://github.com/fullstorydev/grpcurl/releases/download/v{{grpcurl_latest.stdout}}/grpcurl_{{grpcurl_latest.stdout}}_linux_x86_64.tar.gz"
     dest: /usr/local/bin
   when: result_grpcurl.stat.exists == false
   register: test
@@ -32,9 +38,15 @@
 - debug:
     msg: "{{test}}"
 
-- name: "installing opm {{opm_version}}"
+- name: "Check latest opm version"
+  shell: 'curl --silent https://github.com/operator-framework/operator-registry/releases/latest | sed -r "s/^.*tag\/v(.*)\".*$/\1/"'
+  register: opm_latest
+  changed_when: false
+  failed_when: false
+
+- name: "installing opm v{{opm_latest.stdout}}"
   get_url:
-    url: "https://github.com/operator-framework/operator-registry/releases/download/{{opm_version}}/linux-amd64-opm"
+    url: "https://github.com/operator-framework/operator-registry/releases/download/v{{opm_latest.stdout}}/linux-amd64-opm"
     dest: "/usr/local/bin/opm"
   when: result_opm.stat.exists == false
 
@@ -43,9 +55,15 @@
     path: /usr/local/bin/opm
     mode: u=rwx,g=rx,o=rx
 
-- name: "installing openshift client (oc) {{ocp_version}}"
+- name: "Check latest oc {{index_image_version}} version"
+  shell: "curl --silent https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-{{index_image_version|replace('v','')}}/ | grep 'name.*openshift-client-linux-.*.tar.gz' | sed -r 's/^.*openshift-client-linux-(.*).tar.gz.*$/\\1/'"
+  register: oc_latest
+  changed_when: false
+  failed_when: false
+
+- name: "installing openshift client (oc) v{{oc_latest.stdout}}"
   unarchive:
     remote_src: yes
-    src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ocp_version}}/openshift-client-linux-{{ocp_version}}.tar.gz"
+    src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-{{index_image_version|replace('v','')}}/openshift-client-linux-{{oc_latest.stdout}}.tar.gz"
     dest: "/usr/local/bin"
   when: result_oc.stat.exists == false

--- a/Operator-Importing-for-Restricted-Networks/roles/run-custom-index-container-and-mirror/tasks/get_required_images.yaml
+++ b/Operator-Importing-for-Restricted-Networks/roles/run-custom-index-container-and-mirror/tasks/get_required_images.yaml
@@ -9,7 +9,8 @@
 
 - name: extract index db
   shell: for i in /tmp/index_image_data/* ;do gunzip < $i 2> /dev/null | tar --strip-components 1 -C /tmp -xvf - database/index.db 2>/dev/null ; done
-  ignore_errors: yes
+  changed_when: false
+  failed_when: false
 
 - name: check for index.db file
   stat: path=/tmp/index.db
@@ -20,7 +21,7 @@
   when: index_db_stat.stat.exists==false
 
 - name: sqlite3 for the latest bundle version of the operator
-  shell: "sqlite3 /tmp/index.db \"select distinct operatorbundle_name from related_image order by 1;\" | grep {{ required_operator }} | grep -v beta | tail -n 1"
+  shell: "sqlite3 /tmp/index.db \"select distinct operatorbundle_name from related_image order by 1;\" | grep {{ required_operator }} | grep -v beta | sort -V | tail -n 1"
   register: latest_bundle
 
 - name: debug latest version of operator bundle

--- a/Operator-Importing-for-Restricted-Networks/roles/run-custom-index-container-and-mirror/tasks/skopeo-copy-the-relevant-images-and-compress.yaml
+++ b/Operator-Importing-for-Restricted-Networks/roles/run-custom-index-container-and-mirror/tasks/skopeo-copy-the-relevant-images-and-compress.yaml
@@ -5,7 +5,7 @@
 - name: chmod run.sh
   file:
     path: run.sh
-    mode: u+rx,g+rx,o+rx
+    mode: '0755'
 
 - name: Run the script with the skopeo commands
   shell: sudo bash run.sh
@@ -25,11 +25,14 @@
   shell: "/usr/local/bin/opm index prune -f registry.redhat.io/redhat/{{index_image}}-index:{{index_image_version}} -p {{ latest_bundle.stdout.split('.')[0] }},cic-operator -t myregistry:5000/{{ latest_bundle.stdout.split('.')[0] }}-index:{{ latest_bundle.stdout | regex_replace('^.*?\\.') }}; podman push --tls-verify=false --authfile=/run/containers/0/auth.json myregistry:5000/{{ latest_bundle.stdout.split('.')[0] }}-index:{{ latest_bundle.stdout | regex_replace('^.*?\\.') }}"
   when: index_image == 'certified-operator'
 
+- name: Change Source/Target urls at run.sh
+  shell: cat <<< $(awk '{gsub("docker://[A-Za-z0-9:.]+/","docker://myregistry:5000/",$7);gsub("docker://myregistry:5000/","docker://MY_REGISTRY:5000/",$8)}1' run.sh) > run.sh
+
 - name: Add index image to run.sh
-  shell: echo "skopeo copy --all --src-tls-verify=false --dest-tls-verify=false --authfile=/run/containers/0/auth.json docker://registry.redhat.io/{{index_image}}-index:{{index_image_version}} docker://myregistry:5000/{{ latest_bundle.stdout.split('.')[0] }}-index:{{ latest_bundle.stdout | regex_replace('^.*?\\.') }}" >> run.sh
+  shell: "echo skopeo copy --all --src-tls-verify=false --dest-tls-verify=false --authfile=/run/containers/0/auth.json docker://myregistry:5000/{{ latest_bundle.stdout.split('.')[0] }}-index:{{ latest_bundle.stdout | regex_replace('^.*?\\.') }} docker://MY_REGISTRY:5000/{{ latest_bundle.stdout.split('.')[0] }}-index:{{ latest_bundle.stdout | regex_replace('^.*?\\.') }} >> run.sh"
 
 - name: Add releavnt mirrors to imageContentSourcePolicy.yaml file
-  shell: "cat images.txt | while read line; do ORIGINAL_REPOSITORY=\"$(cut -d'/' -f1 <<< $line)\"; HEADLESS_IMAGE=\"$(cut -d'/' -f2- <<< $line)\"; echo -e \"  - mirrors:\\n    - myregistry:5000/$HEADLESS_IMAGE\\n    source: $ORIGINAL_REPOSITORY/$HEADLESS_IMAGE\"; done >> imageContentSourcePolicy.yaml"
+  shell: "cat images.txt | while read line; do ORIGINAL_REPOSITORY=\"$(cut -d'/' -f1 <<< $line)\"; HEADLESS_IMAGE=\"$(cut -d'/' -f2- <<< $line | sed -e 's/@.*$//' -e 's/:.*$//')\"; echo -e \"  - mirrors:\\n    - MY_REGISTRY:5000/$HEADLESS_IMAGE\\n    source: $ORIGINAL_REPOSITORY/$HEADLESS_IMAGE\"; done >> imageContentSourcePolicy.yaml"
 
 - name: Generate catalogSource.yaml
   template:
@@ -38,12 +41,16 @@
           
 - name: "Copy 'run.sh', 'imageContentSourcePolicy.yaml', 'catalogSource.yaml' to '/tmp/myregistry/data' for later compressing all of it together"
   copy:
-    src: "{{ item }}"
-    dest: "/tmp/myregistry/data/{{ item }}"
+    src: "{{ item.name }}"
+    dest: "/tmp/myregistry/data/{{ item.name }}"
+    mode: "{{ item.mode }}"
   with_items:
-    - run.sh
-    - imageContentSourcePolicy.yaml
-    - catalogSource.yaml
+    - name: run.sh
+      mode: '0755'
+    - name: imageContentSourcePolicy.yaml
+      mode: '0644'
+    - name: catalogSource.yaml
+      mode: '0644'
 
 - name: Compress directory /tmp/myregsitry/data
   community.general.archive:

--- a/Operator-Importing-for-Restricted-Networks/roles/run-custom-index-container-and-mirror/templates/catalogSource.yaml.j2
+++ b/Operator-Importing-for-Restricted-Networks/roles/run-custom-index-container-and-mirror/templates/catalogSource.yaml.j2
@@ -5,5 +5,5 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: myregistry:5000/{{ latest_bundle.stdout.split('.')[0] }}-index:{{ latest_bundle.stdout | regex_replace('^.*?\\.') }}
+  image: MY_REGISTRY:5000/{{ latest_bundle.stdout.split('.')[0] }}-index:{{ latest_bundle.stdout | regex_replace('^.*?\\.') }}
   displayName: Imported {{ latest_bundle.stdout.split('.')[0] }} Operator


### PR DESCRIPTION
Changed Operator-Importing-for-Restricted-Networks to be more user friendly
Fixed the start-repository.sh script
Added stop-repository.sh script for cleanups
Playbook performs cleanup after every run even if unseccesful
If opm/oc/grpcurl pull the latest version instead of asking the user for version, in case of oc the version is based on the index_image_version variable version